### PR TITLE
reduce inheritance for clarity

### DIFF
--- a/src/classes/Expect.cls
+++ b/src/classes/Expect.cls
@@ -1,4 +1,4 @@
-public virtual class Expect {
+public abstract class Expect {
     public static Boolean UseSystemAssert = true;
     public static final String SHOULD_BE_MESSAGE = 'Expected {0} should{1} be {2}';
     public static final String SHOULD_BE_LESS_MESSAGE = 'Expected {0} should be less than {1}';
@@ -10,15 +10,9 @@ public virtual class Expect {
     public static final String SHOULD_BE_TRUE_MESSAGE = 'Expected false should be true';
     public static final String SHOULD_CONTAIN_MESSAGE = 'Expected {0} should{1} contain {2}';
 
-    private final Object expected;
-
     protected Expect() {}
 
-    public Expect(Object expected) {
-        this.expected = expected;
-    }
-
-    public Expect andIt { get { return this; } }
+    protected abstract String getExpectedAsString();
 
     public class AssertException extends System.Exception {}
 
@@ -32,36 +26,8 @@ public virtual class Expect {
         }
     }
 
-    public Expect shouldEqual(Object actual) {
-        shouldEqual(actual, expectedMessage(actual,''));
-        return this;
-    }
-
-    public Expect shouldEqual(Object actual, String message) {
-        assert(expected === actual, message);
-        return this;
-    }
-
-    public Expect shouldNotEqual(Object actual) {
-        return shouldNotEqual(actual, expectedMessage(actual,' not'));
-    }
-
-    public Expect shouldNotEqual(Object actual, String message) {
-        assert(expected != actual, message);
-        return this;
-    }
-
-    public Expect isEquivalentTo(Object actual) {
-        return isEquivalentTo(actual, expectedMessage(actual,''));
-    }
-
-    public Expect isEquivalentTo(Object actual, String message) {
-        assert(expected == actual, message);
-        return this;
-    }
-
-    public static Expect that(Object expected) {
-        return new Expect(expected);
+    public static ExpectObject that(Object expected) {
+        return new ExpectObject(expected);
     }
 
     public static ExpectBoolean that(Boolean expected) {
@@ -90,7 +56,7 @@ public virtual class Expect {
 
     protected String expectedMessage(Object actual, String formatString, String delimiter) {
         return String.format(formatString, new String[] {
-            String.valueOf(expected),
+            this.getExpectedAsString(),
             delimiter,
             String.valueOf(actual)
         });

--- a/src/classes/ExpectBoolean.cls
+++ b/src/classes/ExpectBoolean.cls
@@ -2,9 +2,13 @@ public class ExpectBoolean extends Expect {
     private final Boolean expected;
 
     public ExpectBoolean(Boolean expected) {
-        super(expected);
         this.expected = expected;
     }
+
+    protected override String getExpectedAsString() {
+        return String.valueOf(expected);
+    }
+
     public ExpectBoolean andThat { get { return this; } }
 
     public ExpectBoolean shouldBeFalse() {

--- a/src/classes/ExpectDate.cls
+++ b/src/classes/ExpectDate.cls
@@ -2,9 +2,13 @@ public class ExpectDate extends Expect {
     private final Date expected;
 
     public ExpectDate(Date expected) {
-        super(expected);
         this.expected = expected;
     }
+
+    protected override String getExpectedAsString() {
+        return String.valueOf(expected);
+    }
+
     private ExpectDate assertThis(Boolean test, String message) {
         Expect.assert(test, message);
         return this;

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -2,8 +2,11 @@ public class ExpectInteger extends Expect {
     private final Integer expected;
 
     public ExpectInteger(Integer expected) {
-        super(expected);
         this.expected = expected;
+    }
+
+    protected override String getExpectedAsString() {
+        return String.valueOf(expected);
     }
 
     public ExpectInteger andIt { get { return this; } }

--- a/src/classes/ExpectObject.cls
+++ b/src/classes/ExpectObject.cls
@@ -1,0 +1,42 @@
+public class ExpectObject extends Expect {
+
+    private final Object expected;
+
+    public ExpectObject(Object expected) {
+        this.expected = expected;
+    }
+
+    protected override String getExpectedAsString() {
+        return String.valueOf(expected);
+    }
+
+    public ExpectObject andIt { get { return this; } }
+
+    public Expect shouldEqual(Object actual) {
+        shouldEqual(actual, expectedMessage(actual,''));
+        return this;
+    }
+
+    public Expect shouldEqual(Object actual, String message) {
+        assert(expected === actual, message);
+        return this;
+    }
+
+    public Expect shouldNotEqual(Object actual) {
+        return shouldNotEqual(actual, expectedMessage(actual,' not'));
+    }
+
+    public Expect shouldNotEqual(Object actual, String message) {
+        assert(expected != actual, message);
+        return this;
+    }
+
+    public Expect isEquivalentTo(Object actual) {
+        return isEquivalentTo(actual, expectedMessage(actual,''));
+    }
+
+    public Expect isEquivalentTo(Object actual, String message) {
+        assert(expected == actual, message);
+        return this;
+    }
+}

--- a/src/classes/ExpectObject.cls-meta.xml
+++ b/src/classes/ExpectObject.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>37.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/ExpectSObject.cls
+++ b/src/classes/ExpectSObject.cls
@@ -5,8 +5,11 @@ public class ExpectSObject extends Expect {
     private final SObject expected;
 
     public ExpectSObject(SObject expected) {
-        super(expected);
         this.expected = expected;
+    }
+
+    protected override String getExpectedAsString() {
+        return String.valueOf(expected);
     }
 
     public ExpectSObject andIt { get { return this; } }

--- a/src/classes/ExpectString.cls
+++ b/src/classes/ExpectString.cls
@@ -2,8 +2,11 @@ public class ExpectString extends Expect {
     private final String expected;
 
     public ExpectString(String expected) {
-        super(expected);
         this.expected = expected;
+    }
+
+    protected override String getExpectedAsString() {
+        return expected;
     }
 
     public ExpectString shouldEqual(String actual) {


### PR DESCRIPTION
* ExpectObject moved to explicit class in new file

* Expect subclasses must provide their own formatted value through new
  abstract member

(Now the only state in the abstract Expect class is the static member
value)