### PR TITLE
.negate.

### DIFF
--- a/src/classes/Expect.cls
+++ b/src/classes/Expect.cls
@@ -80,23 +80,6 @@ public abstract class Expect {
         return new ExpectId(expected);
     }
 
-    protected String expectedShouldBeMessage(Object actual) {
-        return expectedFormatMessage(SHOULD_BE_MESSAGE, actual);
-    }
-
-    protected String expectedShouldNotBeMessage(Object actual) {
-        return expectedFormatNotMessage(SHOULD_BE_MESSAGE, actual);
-    }
-
-//remove
-    protected String expectedFormatMessage(String formatString, Object actual) {
-        return expectedMessage(formatString, actual, 'should');
-    }
-//remove
-    protected String expectedFormatNotMessage(String formatString, Object actual) {
-        return expectedMessage(formatString, actual, 'should not');
-    }
-
     protected String formatMessage(String formatString, Object actual) {
         return expectedMessage(formatString, actual, shouldOrShouldNot);
     }

--- a/src/classes/Expect.cls
+++ b/src/classes/Expect.cls
@@ -7,10 +7,21 @@ public abstract class Expect {
     public static final String SHOULD_BE_GREATER_OR_EQUAL_MESSAGE = 'Expected {0} {1} be greater than or equal to {2}';
     private static final String SHOULD_BE_BETWEEN_MESSAGE = 'Expected {0} {1} be between {2} and {3}';
     public static final String SHOULD_CONTAIN_MESSAGE = 'Expected {0} {1} contain {2}';
+    protected final Boolean negate;
 
-    protected Expect() {}
-
+    protected Expect() {
+        negate = false;
+    }
+    protected Expect(boolean negatedState) {
+        negate = negatedState;
+    }
     protected abstract String getExpectedAsString();
+
+    private string shouldOrShouldNot {
+        get {
+            return negate ? 'should not' : 'should';
+        }
+    }
 
     public class AssertException extends System.Exception {}
 
@@ -20,6 +31,10 @@ public abstract class Expect {
         } else if (!expected) {
             throw new Expect.AssertException(message);
         }
+    }
+
+    protected void assertNegatable(Boolean testResult, String message) {
+        Expect.assert(negate ? !testResult : testResult, message);
     }
 
     public static ExpectObject that(Object expected) {
@@ -74,10 +89,14 @@ public abstract class Expect {
         return expectedMessage(formatString, actual, 'should not');
     }
 
+    protected String formatMessage(String formatString, Object actual) {
+        return expectedMessage(formatString, actual, shouldOrShouldNot);
+    }
+
     protected String expectedShouldBeBetweenMessage(Object beginRange, Object endRange) {
         return String.format(SHOULD_BE_BETWEEN_MESSAGE, new String[] {
             this.getExpectedAsString(),
-            'should',
+            shouldOrShouldNot,
             String.valueOf(beginRange),
             String.valueOf(endRange)
         });

--- a/src/classes/Expect.cls
+++ b/src/classes/Expect.cls
@@ -1,4 +1,7 @@
 public abstract class Expect {
+    public class ExpectNegation {
+        private ExpectNegation() {}
+    }
     public static Boolean UseSystemAssert = true;
     public static final String SHOULD_BE_MESSAGE = 'Expected {0} {1} be {2}';
     public static final String SHOULD_BE_LESS_MESSAGE = 'Expected {0} {1} be less than {2}';
@@ -8,12 +11,19 @@ public abstract class Expect {
     private static final String SHOULD_BE_BETWEEN_MESSAGE = 'Expected {0} {1} be between {2} and {3}';
     public static final String SHOULD_CONTAIN_MESSAGE = 'Expected {0} {1} contain {2}';
     protected final Boolean negate;
+    public static final ExpectNegation NegatedAssert = new ExpectNegation();
+    protected final Expect parentInstance;
 
     protected Expect() {
         negate = false;
+        parentInstance = this;
     }
     protected Expect(boolean negatedState) {
         negate = negatedState;
+    }
+    protected Expect(ExpectNegation forceNegated, Expect parent) {
+        negate = true;
+        parentInstance = parent;
     }
     protected abstract String getExpectedAsString();
 
@@ -25,16 +35,13 @@ public abstract class Expect {
 
     public class AssertException extends System.Exception {}
 
-    public static void assert(Boolean expected, String message) {
+    protected void assertNegatable(Boolean testResult, String message) {
+        Boolean expected = negate ? !testResult : testResult;
         if(UseSystemAssert) {
             System.assert(expected, message);
         } else if (!expected) {
             throw new Expect.AssertException(message);
         }
-    }
-
-    protected void assertNegatable(Boolean testResult, String message) {
-        Expect.assert(negate ? !testResult : testResult, message);
     }
 
     public static ExpectObject that(Object expected) {
@@ -81,10 +88,11 @@ public abstract class Expect {
         return expectedFormatNotMessage(SHOULD_BE_MESSAGE, actual);
     }
 
+//remove
     protected String expectedFormatMessage(String formatString, Object actual) {
         return expectedMessage(formatString, actual, 'should');
     }
-
+//remove
     protected String expectedFormatNotMessage(String formatString, Object actual) {
         return expectedMessage(formatString, actual, 'should not');
     }

--- a/src/classes/ExpectBoolean.cls
+++ b/src/classes/ExpectBoolean.cls
@@ -31,7 +31,7 @@ public class ExpectBoolean extends Expect {
     }
 
     public ExpectBoolean shouldEqual(Boolean actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(actual));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, actual));
     }
 
     public ExpectBoolean shouldEqual(Boolean actual, String message) {

--- a/src/classes/ExpectBoolean.cls
+++ b/src/classes/ExpectBoolean.cls
@@ -3,12 +3,16 @@ public class ExpectBoolean extends Expect {
     public ExpectBoolean(Boolean expected) {
         this.expected = expected;
     }
+    private ExpectBoolean(ExpectBoolean existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
+    }
 
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
 
-    public ExpectBoolean andIt { get { return this; } }
+    public ExpectBoolean andIt { get { return (ExpectBoolean) parentInstance; } }
 
     public ExpectBoolean shouldBeFalse() {
         return shouldEqual(false);
@@ -31,7 +35,13 @@ public class ExpectBoolean extends Expect {
     }
 
     public ExpectBoolean shouldEqual(Boolean actual, String message) {
-        Expect.assert(expected == actual, message);
-        return this;
+        assertNegatable(this.expected == actual, message);
+        return (ExpectBoolean) parentInstance;
     }
+    public ExpectBoolean negated {
+        get {
+            return new ExpectBoolean(this);
+        }
+    }
+
 }

--- a/src/classes/ExpectBoolean_Tests.cls
+++ b/src/classes/ExpectBoolean_Tests.cls
@@ -90,4 +90,11 @@ public class ExpectBoolean_Tests {
         final Boolean TRUE_VALUE = true;
         Expect.that(TRUE_VALUE).shouldBeTrue().andIt.shouldEqual(TRUE_VALUE);
     }
+
+    @isTest
+    public static void ExpectBooleanSupportsNegation() {
+        Expect.that(true).negated.andIt.shouldBeTrue(); // andIt removes negation
+        Expect.that(true).negated.shouldBeFalse() // negation works
+            .shouldBeTrue(); // evaluating once removes negation
+    }
 }

--- a/src/classes/ExpectDate.cls
+++ b/src/classes/ExpectDate.cls
@@ -28,25 +28,25 @@ public class ExpectDate extends Expect {
         return assertThis(expected < actual, message);
     }
     public ExpectDate shouldBeLessThan(Date actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDate shouldBeLessThanOrEqualTo(Date actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public ExpectDate shouldBeLessThanOrEqualTo(Date actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDate shouldBeGreaterThan(Date actual, string message) {
         return assertThis(expected > actual, message);
     }
     public ExpectDate shouldBeGreaterThan(Date actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDate shouldBeGreaterThanOrEqualTo(Date actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public ExpectDate shouldBeGreaterThanOrEqualTo(Date actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDate shouldBeBetween(Date rangeStart, Date rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/src/classes/ExpectDate.cls
+++ b/src/classes/ExpectDate.cls
@@ -1,27 +1,22 @@
 public class ExpectDate extends Expect {
     protected final Date expected;
-    protected final ExpectDate parent;
 
     public ExpectDate(Date expected) {
-        this.parent = this;
         this.expected = expected;
     }
-    private ExpectDate(Date expected, Boolean negate, ExpectDate parent) {
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+    private ExpectDate(ExpectDate existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
-    public ExpectDate negated {
-        get {
-            return negate ? this : new ExpectDate(this.expected, true, this);
-        }
-    }
+
+    public ExpectDate negated { get { return new ExpectDate(this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectDate assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return this.parent;
+        return (ExpectDate) parentInstance;
     }
     public ExpectDate shouldEqual(Date actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -63,5 +58,5 @@ public class ExpectDate extends Expect {
 
         return assertThis(testedBetween, message);
     }
-    public ExpectDate andIt { get { return this; } }
+    public ExpectDate andIt { get { return (ExpectDate) parentInstance; } }
 }

--- a/src/classes/ExpectDate.cls
+++ b/src/classes/ExpectDate.cls
@@ -1,27 +1,33 @@
 public class ExpectDate extends Expect {
     protected final Date expected;
+    protected final ExpectDate parent;
 
     public ExpectDate(Date expected) {
         this.expected = expected;
+        this.parent = this;
+    }
+    private ExpectDate(Date expected, Boolean negate, ExpectDate parent) {
+        super(negate);
+        this.expected = expected;
+        this.parent = parent;
+    }
+    public ExpectDate negated {
+        get {
+            return negate ? this : new ExpectDate(this.expected, true, this);
+        }
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectDate assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return this;
+        assertNegatable(test, message);
+        return this.parent;
     }
     public ExpectDate shouldEqual(Date actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDate shouldEqual(Date actual, String message) {
         return assertThis(expected == actual, message);
-    }
-    public ExpectDate shouldNotEqual(Date actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public ExpectDate shouldNotEqual(Date actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public ExpectDate shouldBeLessThan(Date actual, string message) {
         return assertThis(expected < actual, message);

--- a/src/classes/ExpectDate.cls
+++ b/src/classes/ExpectDate.cls
@@ -3,8 +3,8 @@ public class ExpectDate extends Expect {
     protected final ExpectDate parent;
 
     public ExpectDate(Date expected) {
-        this.expected = expected;
         this.parent = this;
+        this.expected = expected;
     }
     private ExpectDate(Date expected, Boolean negate, ExpectDate parent) {
         super(negate);

--- a/src/classes/ExpectDate_Tests.cls
+++ b/src/classes/ExpectDate_Tests.cls
@@ -35,15 +35,15 @@ public class ExpectDate_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that(DATE_LOWEST).shouldNotEqual(DATE_MIDDLE);
+        Expect.that(DATE_LOWEST).negated.shouldEqual(DATE_MIDDLE);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(DATE_LOWEST).shouldNotEqual(DATE_LOWEST);
+            Expect.that(DATE_LOWEST).negated.shouldEqual(DATE_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that(DATE_LOWEST).shouldNotEqual(DATE_LOWEST, message);
+            Expect.that(DATE_LOWEST).negated.shouldEqual(DATE_LOWEST, message);
         }
     }
 
@@ -62,6 +62,12 @@ public class ExpectDate_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(DATE_LOWEST).shouldBeLessThan(DATE_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that(DATE_MIDDLE).negated.shouldBeLessThan(DATE_LOWEST)
+            .andIt.shouldBeLessThan(DATE_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -191,6 +197,27 @@ public class ExpectDate_Tests {
     @isTest
     static void ExpectShouldBeBetweenThrowsSpecificMessage() {
         new ShouldBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that(DATE_MIDDLE).negated.shouldBeBetween(DATE_LOWEST, DATE_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that(DATE_MIDDLE).negated.shouldBeBetween(DATE_LOWEST, DATE_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + DATE_MIDDLE_S + ' should not be between ' + DATE_LOWEST_S + ' and ' + DATE_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
             .verifyCustomMessage('outside allowed range');
     }
 

--- a/src/classes/ExpectDatetime.cls
+++ b/src/classes/ExpectDatetime.cls
@@ -28,25 +28,25 @@ public class ExpectDatetime extends Expect {
         return assertThis(expected < actual, message);
     }
     public ExpectDatetime shouldBeLessThan(Datetime actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDatetime shouldBeLessThanOrEqualTo(Datetime actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public ExpectDatetime shouldBeLessThanOrEqualTo(Datetime actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDatetime shouldBeGreaterThan(Datetime actual, string message) {
         return assertThis(expected > actual, message);
     }
     public ExpectDatetime shouldBeGreaterThan(Datetime actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDatetime shouldBeGreaterThanOrEqualTo(Datetime actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public ExpectDatetime shouldBeGreaterThanOrEqualTo(Datetime actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDatetime shouldBeBetween(Datetime rangeStart, Datetime rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/src/classes/ExpectDatetime.cls
+++ b/src/classes/ExpectDatetime.cls
@@ -3,8 +3,8 @@ public class ExpectDatetime extends Expect {
     protected final ExpectDatetime parent;
 
     public ExpectDatetime(Datetime expected) {
-        this.expected = expected;
         this.parent = this;
+        this.expected = expected;
     }
     private ExpectDatetime(Datetime expected, Boolean negate, ExpectDatetime parent) {
         super(negate);

--- a/src/classes/ExpectDatetime.cls
+++ b/src/classes/ExpectDatetime.cls
@@ -1,27 +1,33 @@
 public class ExpectDatetime extends Expect {
     protected final Datetime expected;
+    protected final ExpectDatetime parent;
 
     public ExpectDatetime(Datetime expected) {
         this.expected = expected;
+        this.parent = this;
+    }
+    private ExpectDatetime(Datetime expected, Boolean negate, ExpectDatetime parent) {
+        super(negate);
+        this.expected = expected;
+        this.parent = parent;
+    }
+    public ExpectDatetime negated {
+        get {
+            return negate ? this : new ExpectDatetime(this.expected, true, this);
+        }
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectDatetime assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return this;
+        assertNegatable(test, message);
+        return this.parent;
     }
     public ExpectDatetime shouldEqual(Datetime actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public ExpectDatetime shouldEqual(Datetime actual, String message) {
         return assertThis(expected == actual, message);
-    }
-    public ExpectDatetime shouldNotEqual(Datetime actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public ExpectDatetime shouldNotEqual(Datetime actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public ExpectDatetime shouldBeLessThan(Datetime actual, string message) {
         return assertThis(expected < actual, message);

--- a/src/classes/ExpectDatetime.cls
+++ b/src/classes/ExpectDatetime.cls
@@ -1,27 +1,22 @@
 public class ExpectDatetime extends Expect {
     protected final Datetime expected;
-    protected final ExpectDatetime parent;
 
     public ExpectDatetime(Datetime expected) {
-        this.parent = this;
         this.expected = expected;
     }
-    private ExpectDatetime(Datetime expected, Boolean negate, ExpectDatetime parent) {
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+    private ExpectDatetime(ExpectDatetime existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
-    public ExpectDatetime negated {
-        get {
-            return negate ? this : new ExpectDatetime(this.expected, true, this);
-        }
-    }
+
+    public ExpectDatetime negated { get { return new ExpectDatetime(this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectDatetime assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return this.parent;
+        return (ExpectDatetime) parentInstance;
     }
     public ExpectDatetime shouldEqual(Datetime actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -63,5 +58,5 @@ public class ExpectDatetime extends Expect {
 
         return assertThis(testedBetween, message);
     }
-    public ExpectDatetime andIt { get { return this; } }
+    public ExpectDatetime andIt { get { return (ExpectDatetime) parentInstance; } }
 }

--- a/src/classes/ExpectDatetime_Tests.cls
+++ b/src/classes/ExpectDatetime_Tests.cls
@@ -35,15 +35,15 @@ public class ExpectDatetime_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that(DATETIME_LOWEST).shouldNotEqual(DATETIME_MIDDLE);
+        Expect.that(DATETIME_LOWEST).negated.shouldEqual(DATETIME_MIDDLE);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(DATETIME_LOWEST).shouldNotEqual(DATETIME_LOWEST);
+            Expect.that(DATETIME_LOWEST).negated.shouldEqual(DATETIME_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that(DATETIME_LOWEST).shouldNotEqual(DATETIME_LOWEST, message);
+            Expect.that(DATETIME_LOWEST).negated.shouldEqual(DATETIME_LOWEST, message);
         }
     }
 
@@ -62,6 +62,12 @@ public class ExpectDatetime_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(DATETIME_LOWEST).shouldBeLessThan(DATETIME_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that(DATETIME_MIDDLE).negated.shouldBeLessThan(DATETIME_LOWEST)
+            .andIt.shouldBeLessThan(DATETIME_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -191,6 +197,27 @@ public class ExpectDatetime_Tests {
     @isTest
     static void ExpectShouldBeBetweenThrowsSpecificMessage() {
         new ShouldBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that(DATETIME_MIDDLE).negated.shouldBeBetween(DATETIME_LOWEST, DATETIME_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that(DATETIME_MIDDLE).negated.shouldBeBetween(DATETIME_LOWEST, DATETIME_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + DATETIME_MIDDLE_S + ' should not be between ' + DATETIME_LOWEST_S + ' and ' + DATETIME_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
             .verifyCustomMessage('outside allowed range');
     }
 

--- a/src/classes/ExpectError.cls
+++ b/src/classes/ExpectError.cls
@@ -52,14 +52,6 @@ public class ExpectError {
             wrappedString.shouldContain(actual, message);
             return parent;
         }
-        public ExpectStringDecorator shouldNotContain(String actual) {
-            wrappedString.shouldNotContain(actual);
-            return parent;
-        }
-        public ExpectStringDecorator shouldNotContain(String actual, String message) {
-            wrappedString.shouldNotContain(actual, message);
-            return parent;
-        }
         public ExpectStringDecorator shouldEqual(String actual) {
             wrappedString.shouldEqual(actual);
             return parent;

--- a/src/classes/ExpectError.cls
+++ b/src/classes/ExpectError.cls
@@ -18,9 +18,17 @@ public class ExpectError {
     public class ExpectStringDecorator {
         private final ExpectError wrapped;
         private final ExpectString wrappedString;
+        private final ExpectStringDecorator parent;
         private ExpectStringDecorator(String value, ExpectError wrapped) {
             this.wrapped = wrapped;
             this.wrappedString = new ExpectString(value);
+            this.parent = this;
+        }
+        // negation constructor
+        private ExpectStringDecorator(ExpectStringDecorator parent) {
+            this.wrapped = parent.wrapped;
+            this.wrappedString = parent.wrappedString.negated;
+            this.parent = parent;
         }
         public ExpectStringDecorator andErrorMessage {
             get { return wrapped.andErrorMessage; }
@@ -30,43 +38,40 @@ public class ExpectError {
         }
         public ExpectStringDecorator shouldEqualIgnoreOrdinalCase(String actual) {
             wrappedString.shouldEqualIgnoreOrdinalCase(actual);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldEqualIgnoreOrdinalCase(String actual, String message) {
             wrappedString.shouldEqualIgnoreOrdinalCase(actual, message);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldContain(String actual) {
             wrappedString.shouldContain(actual);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldContain(String actual, String message) {
             wrappedString.shouldContain(actual, message);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldNotContain(String actual) {
             wrappedString.shouldNotContain(actual);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldNotContain(String actual, String message) {
             wrappedString.shouldNotContain(actual, message);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldEqual(String actual) {
             wrappedString.shouldEqual(actual);
-            return this;
+            return parent;
         }
         public ExpectStringDecorator shouldEqual(String actual, String message) {
             wrappedString.shouldEqual(actual, message);
-            return this;
+            return parent;
         }
-        public ExpectStringDecorator shouldNotEqual(String actual) {
-            wrappedString.negated.shouldEqual(actual);
-            return this;
-        }
-        public ExpectStringDecorator shouldNotEqual(String actual, String message) {
-            wrappedString.negated.shouldEqual(actual, message);
-            return this;
+        public ExpectStringDecorator negated {
+            get {
+                return new ExpectStringDecorator(this);
+            }
         }
     }
 }

--- a/src/classes/ExpectError.cls
+++ b/src/classes/ExpectError.cls
@@ -61,11 +61,11 @@ public class ExpectError {
             return this;
         }
         public ExpectStringDecorator shouldNotEqual(String actual) {
-            wrappedString.shouldNotEqual(actual);
+            wrappedString.negated.shouldEqual(actual);
             return this;
         }
         public ExpectStringDecorator shouldNotEqual(String actual, String message) {
-            wrappedString.shouldNotEqual(actual, message);
+            wrappedString.negated.shouldEqual(actual, message);
             return this;
         }
     }

--- a/src/classes/ExpectError_Tests.cls
+++ b/src/classes/ExpectError_Tests.cls
@@ -1,10 +1,15 @@
 @isTest
 public class ExpectError_Tests {
-    private static final Exception nullPtr = new NullPointerException();
+    private static final Exception nullPtr = setupException();
+
+    static Exception setupException() {
+        Exception ex = new NullPointerException();
+        ex.setMessage('explode');
+        return ex;
+    }
 
     @isTest
     static void ExpectErrorShouldExposeErrorMessageAsExpectString() {
-        nullPtr.setMessage('explode');
         ExpectError wrappedError = new ExpectError(nullPtr);
         wrappedError.andErrorMessage
             .shouldEqual(nullPtr.getMessage());
@@ -19,10 +24,20 @@ public class ExpectError_Tests {
 
     @isTest
     static void ExpectErrorShouldChainMessageAndErrorType() {
-        nullPtr.setMessage('explode');
         new ExpectError(nullPtr)
             .andErrorType.shouldEqual(nullPtr.getTypeName())
             .andErrorMessage.shouldEqual(nullPtr.getMessage());
+    }
+
+    @isTest
+    static void ExpectErrorShouldNegate() {
+        new ExpectError(nullPtr)
+            .andErrorType
+                .negated.shouldEqual('assemble')
+                .shouldEqual(nullPtr.getTypeName()) // verify negation lasts for 1 assert
+            .andErrorMessage
+                .negated.shouldEqual('shuffle')
+                .shouldEqual(nullPtr.getMessage()); // verify negation lasts for 1 assert
     }
 
 }

--- a/src/classes/ExpectId.cls
+++ b/src/classes/ExpectId.cls
@@ -1,27 +1,33 @@
 public class ExpectId extends Expect {
     protected final Id expected;
+    protected final ExpectId parent;
 
     public ExpectId(Id expected) {
         this.expected = expected;
+        this.parent = this;
+    }
+    private ExpectId(Id expected, Boolean negate, ExpectId parent) {
+        super(negate);
+        this.expected = expected;
+        this.parent = parent;
+    }
+    public ExpectId negated {
+        get {
+            return negate ? this : new ExpectId(this.expected, true, this);
+        }
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectId assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return this;
+        assertNegatable(test, message);
+        return this.parent;
     }
     public ExpectId shouldEqual(Id actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public ExpectId shouldEqual(Id actual, String message) {
         return assertThis(expected == actual, message);
-    }
-    public ExpectId shouldNotEqual(Id actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public ExpectId shouldNotEqual(Id actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public ExpectId shouldBeLessThan(Id actual, string message) {
         return assertThis(expected < actual, message);

--- a/src/classes/ExpectId.cls
+++ b/src/classes/ExpectId.cls
@@ -3,8 +3,8 @@ public class ExpectId extends Expect {
     protected final ExpectId parent;
 
     public ExpectId(Id expected) {
-        this.expected = expected;
         this.parent = this;
+        this.expected = expected;
     }
     private ExpectId(Id expected, Boolean negate, ExpectId parent) {
         super(negate);

--- a/src/classes/ExpectId.cls
+++ b/src/classes/ExpectId.cls
@@ -28,25 +28,25 @@ public class ExpectId extends Expect {
         return assertThis(expected < actual, message);
     }
     public ExpectId shouldBeLessThan(Id actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public ExpectId shouldBeLessThanOrEqualTo(Id actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public ExpectId shouldBeLessThanOrEqualTo(Id actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectId shouldBeGreaterThan(Id actual, string message) {
         return assertThis(expected > actual, message);
     }
     public ExpectId shouldBeGreaterThan(Id actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public ExpectId shouldBeGreaterThanOrEqualTo(Id actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public ExpectId shouldBeGreaterThanOrEqualTo(Id actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectId shouldBeBetween(Id rangeStart, Id rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/src/classes/ExpectId.cls
+++ b/src/classes/ExpectId.cls
@@ -1,27 +1,22 @@
 public class ExpectId extends Expect {
     protected final Id expected;
-    protected final ExpectId parent;
 
     public ExpectId(Id expected) {
-        this.parent = this;
         this.expected = expected;
     }
-    private ExpectId(Id expected, Boolean negate, ExpectId parent) {
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+    private ExpectId(ExpectId existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
-    public ExpectId negated {
-        get {
-            return negate ? this : new ExpectId(this.expected, true, this);
-        }
-    }
+
+    public ExpectId negated { get { return new ExpectId(this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectId assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return this.parent;
+        return (ExpectId) parentInstance;
     }
     public ExpectId shouldEqual(Id actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -63,5 +58,5 @@ public class ExpectId extends Expect {
 
         return assertThis(testedBetween, message);
     }
-    public ExpectId andIt { get { return this; } }
+    public ExpectId andIt { get { return (ExpectId) parentInstance; } }
 }

--- a/src/classes/ExpectId_Tests.cls
+++ b/src/classes/ExpectId_Tests.cls
@@ -35,15 +35,15 @@ public class ExpectId_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that(ID_LOWEST).shouldNotEqual(ID_MIDDLE);
+        Expect.that(ID_LOWEST).negated.shouldEqual(ID_MIDDLE);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(ID_LOWEST).shouldNotEqual(ID_LOWEST);
+            Expect.that(ID_LOWEST).negated.shouldEqual(ID_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that(ID_LOWEST).shouldNotEqual(ID_LOWEST, message);
+            Expect.that(ID_LOWEST).negated.shouldEqual(ID_LOWEST, message);
         }
     }
 
@@ -62,6 +62,12 @@ public class ExpectId_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(ID_LOWEST).shouldBeLessThan(ID_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that(ID_MIDDLE).negated.shouldBeLessThan(ID_LOWEST)
+            .andIt.shouldBeLessThan(ID_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -191,6 +197,27 @@ public class ExpectId_Tests {
     @isTest
     static void ExpectShouldBeBetweenThrowsSpecificMessage() {
         new ShouldBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that(ID_MIDDLE).negated.shouldBeBetween(ID_LOWEST, ID_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that(ID_MIDDLE).negated.shouldBeBetween(ID_LOWEST, ID_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + ID_MIDDLE_S + ' should not be between ' + ID_LOWEST_S + ' and ' + ID_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
             .verifyCustomMessage('outside allowed range');
     }
 

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -1,27 +1,56 @@
 public class ExpectInteger extends Expect {
     protected final Integer expected;
+    protected final Boolean negate;
+    protected final ExpectInteger parent;
 
     public ExpectInteger(Integer expected) {
         this.expected = expected;
+        this.negate = false;
+        this.parent = this;
+    }
+    public ExpectInteger(Integer expected, Boolean negate, ExpectInteger parent) {
+        this.expected = expected;
+        this.negate = negate;
+        this.parent = parent;
+    }
+    public ExpectInteger nnot {
+        get {
+            return negate ? this : new ExpectInteger(this.expected, true, this);
+        }
+    }
+    public ExpectInteger negated {
+        get {
+            return nnot;
+        }
+    }
+    public ExpectInteger shouldBe {
+        get {
+            return this;
+        }
+    }
+    public ExpectInteger shouldNotBe {
+        get {
+            return nnot;
+        }
+    }
+    public ExpectInteger lessThan(Integer actual) {
+        return shouldBeLessThan(actual);
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectInteger assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return this;
+        Expect.assert(negate ? !test : test, message);
+        return this.parent;
     }
-    public ExpectInteger shouldEqual(Integer actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+    public ExpectInteger toEqual(Integer actual) {
+        return toEqual(actual,
+            negate ? expectedShouldNotBeMessage(String.valueOf(actual)) :
+            expectedShouldBeMessage(String.valueOf(actual))
+        );
     }
-    public ExpectInteger shouldEqual(Integer actual, String message) {
+    public ExpectInteger toEqual(Integer actual, String message) {
         return assertThis(expected == actual, message);
-    }
-    public ExpectInteger shouldNotEqual(Integer actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public ExpectInteger shouldNotEqual(Integer actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public ExpectInteger shouldBeLessThan(Integer actual, string message) {
         return assertThis(expected < actual, message);
@@ -58,4 +87,6 @@ public class ExpectInteger extends Expect {
         return assertThis(testedBetween, message);
     }
     public ExpectInteger andIt { get { return this; } }
+    public ExpectInteger andShouldBe { get { return this; } }
+    public ExpectInteger andShouldNotBe { get { return this.negated; } }
 }

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -3,8 +3,8 @@ public class ExpectInteger extends Expect {
     protected final ExpectInteger parent;
 
     public ExpectInteger(Integer expected) {
-        this.expected = expected;
         this.parent = this;
+        this.expected = expected;
     }
     private ExpectInteger(Integer expected, Boolean negate, ExpectInteger parent) {
         super(negate);

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -28,25 +28,25 @@ public class ExpectInteger extends Expect {
         return assertThis(expected < actual, message);
     }
     public ExpectInteger shouldBeLessThan(Integer actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public ExpectInteger shouldBeLessThanOrEqualTo(Integer actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public ExpectInteger shouldBeLessThanOrEqualTo(Integer actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectInteger shouldBeGreaterThan(Integer actual, string message) {
         return assertThis(expected > actual, message);
     }
     public ExpectInteger shouldBeGreaterThan(Integer actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public ExpectInteger shouldBeGreaterThanOrEqualTo(Integer actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public ExpectInteger shouldBeGreaterThanOrEqualTo(Integer actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectInteger shouldBeBetween(Integer rangeStart, Integer rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -13,28 +13,10 @@ public class ExpectInteger extends Expect {
         this.negate = negate;
         this.parent = parent;
     }
-    public ExpectInteger nnot {
+    public ExpectInteger negated {
         get {
             return negate ? this : new ExpectInteger(this.expected, true, this);
         }
-    }
-    public ExpectInteger negated {
-        get {
-            return nnot;
-        }
-    }
-    public ExpectInteger shouldBe {
-        get {
-            return this;
-        }
-    }
-    public ExpectInteger shouldNotBe {
-        get {
-            return nnot;
-        }
-    }
-    public ExpectInteger lessThan(Integer actual) {
-        return shouldBeLessThan(actual);
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
@@ -43,13 +25,13 @@ public class ExpectInteger extends Expect {
         Expect.assert(negate ? !test : test, message);
         return this.parent;
     }
-    public ExpectInteger toEqual(Integer actual) {
-        return toEqual(actual,
+    public ExpectInteger shouldEqual(Integer actual) {
+        return shouldEqual(actual,
             negate ? expectedShouldNotBeMessage(String.valueOf(actual)) :
             expectedShouldBeMessage(String.valueOf(actual))
         );
     }
-    public ExpectInteger toEqual(Integer actual, String message) {
+    public ExpectInteger shouldEqual(Integer actual, String message) {
         return assertThis(expected == actual, message);
     }
     public ExpectInteger shouldBeLessThan(Integer actual, string message) {
@@ -87,6 +69,4 @@ public class ExpectInteger extends Expect {
         return assertThis(testedBetween, message);
     }
     public ExpectInteger andIt { get { return this; } }
-    public ExpectInteger andShouldBe { get { return this; } }
-    public ExpectInteger andShouldNotBe { get { return this.negated; } }
 }

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -1,16 +1,14 @@
 public class ExpectInteger extends Expect {
     protected final Integer expected;
-    protected final Boolean negate;
     protected final ExpectInteger parent;
 
     public ExpectInteger(Integer expected) {
         this.expected = expected;
-        this.negate = false;
         this.parent = this;
     }
-    public ExpectInteger(Integer expected, Boolean negate, ExpectInteger parent) {
+    private ExpectInteger(Integer expected, Boolean negate, ExpectInteger parent) {
+        super(negate);
         this.expected = expected;
-        this.negate = negate;
         this.parent = parent;
     }
     public ExpectInteger negated {
@@ -22,14 +20,11 @@ public class ExpectInteger extends Expect {
         return String.valueOf(expected);
     }
     private ExpectInteger assertThis(Boolean test, String message) {
-        Expect.assert(negate ? !test : test, message);
+        assertNegatable(test, message);
         return this.parent;
     }
     public ExpectInteger shouldEqual(Integer actual) {
-        return shouldEqual(actual,
-            negate ? expectedShouldNotBeMessage(String.valueOf(actual)) :
-            expectedShouldBeMessage(String.valueOf(actual))
-        );
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public ExpectInteger shouldEqual(Integer actual, String message) {
         return assertThis(expected == actual, message);

--- a/src/classes/ExpectInteger.cls
+++ b/src/classes/ExpectInteger.cls
@@ -1,27 +1,22 @@
 public class ExpectInteger extends Expect {
     protected final Integer expected;
-    protected final ExpectInteger parent;
 
     public ExpectInteger(Integer expected) {
-        this.parent = this;
         this.expected = expected;
     }
-    private ExpectInteger(Integer expected, Boolean negate, ExpectInteger parent) {
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+    private ExpectInteger(ExpectInteger existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
-    public ExpectInteger negated {
-        get {
-            return negate ? this : new ExpectInteger(this.expected, true, this);
-        }
-    }
+
+    public ExpectInteger negated { get { return new ExpectInteger(this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     private ExpectInteger assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return this.parent;
+        return (ExpectInteger) parentInstance;
     }
     public ExpectInteger shouldEqual(Integer actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -63,5 +58,5 @@ public class ExpectInteger extends Expect {
 
         return assertThis(testedBetween, message);
     }
-    public ExpectInteger andIt { get { return this; } }
+    public ExpectInteger andIt { get { return (ExpectInteger) parentInstance; } }
 }

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -13,15 +13,15 @@ public class ExpectInteger_Tests {
 
     @isTest
     static void ExpectShouldEqualMatchingValueDoesNotThrow() {
-        expect(INTEGER_LOWEST).toEqual(INTEGER_LOWEST);
+        expect(INTEGER_LOWEST).shouldEqual(INTEGER_LOWEST);
     }
 
     private class ShouldEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            expect(INTEGER_LOWEST).toEqual(INTEGER_MIDDLE);
+            expect(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE);
         }
         protected override void testCase(string message) {
-            expect(INTEGER_LOWEST).toEqual(INTEGER_MIDDLE, message);
+            expect(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE, message);
         }
     }
 
@@ -39,21 +39,21 @@ public class ExpectInteger_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_MIDDLE);
+        expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE);
     }
 
     @isTest
-    static void ExpectNNotLastsForOneTest() {
-        expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_MIDDLE)
-            .toEqual(INTEGER_LOWEST);
+    static void ExpectNegatedLastsForOneTest() {
+        expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE)
+            .shouldEqual(INTEGER_LOWEST);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_LOWEST);
+            expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST);
         }
         protected override void testCase(string message) {
-            expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_LOWEST, message);
+            expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST, message);
         }
     }
 
@@ -72,16 +72,15 @@ public class ExpectInteger_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(INTEGER_LOWEST).shouldBeLessThan(INTEGER_MIDDLE);
-        Expect.that(INTEGER_LOWEST).shouldBe.lessThan(INTEGER_MIDDLE)
-            .andShouldBe.lessThan(INTEGER_HIGHEST);
     }
 
     @isTest
     static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
         Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST);
 
-        Expect.that(INTEGER_MIDDLE).shouldNotBe.lessThan(INTEGER_LOWEST)
-            .andShouldNotBe.lessThan(-INTEGER_MIDDLE);
+        Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST)
+            .andIt.shouldBeLessThan(INTEGER_HIGHEST)
+            .negated.shouldBeLessThan(-INTEGER_MIDDLE);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -217,7 +216,7 @@ public class ExpectInteger_Tests {
     @isTest
     static void ExpectIntegerChains() {
         Expect.that(INTEGER_LOWEST).shouldBeLessThan(INTEGER_MIDDLE)
-            .andit.toEqual(INTEGER_LOWEST);
+            .andit.shouldEqual(INTEGER_LOWEST);
     }
 
 }

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -207,6 +207,27 @@ public class ExpectInteger_Tests {
             .verifyCustomMessage('outside allowed range');
     }
 
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that(INTEGER_MIDDLE).negated.shouldBeBetween(INTEGER_LOWEST, INTEGER_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that(INTEGER_MIDDLE).negated.shouldBeBetween(INTEGER_LOWEST, INTEGER_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + INTEGER_MIDDLE_S + ' should not be between ' + INTEGER_LOWEST_S + ' and ' + INTEGER_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
     @isTest
     static void ExpectIntegerChains() {
         Expect.that(INTEGER_LOWEST).shouldBeLessThan(INTEGER_MIDDLE)

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -72,11 +72,9 @@ public class ExpectInteger_Tests {
 
     @isTest
     static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
-        Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST);
-
         Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST)
             .andIt.shouldBeLessThan(INTEGER_HIGHEST)
-            .negated.shouldBeLessThan(-INTEGER_MIDDLE);
+            .andIt.negated.shouldBeLessThan(-INTEGER_MIDDLE);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -7,21 +7,17 @@ public class ExpectInteger_Tests {
     private static final String INTEGER_MIDDLE_S = String.valueOf(INTEGER_MIDDLE);
     private static final String INTEGER_HIGHEST_S = String.valueOf(INTEGER_HIGHEST);
 
-    private static ExpectInteger expect(Integer i) {
-        return Expect.that(i);
-    }
-
     @isTest
     static void ExpectShouldEqualMatchingValueDoesNotThrow() {
-        expect(INTEGER_LOWEST).shouldEqual(INTEGER_LOWEST);
+        Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_LOWEST);
     }
 
     private class ShouldEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            expect(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE);
+            Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE);
         }
         protected override void testCase(string message) {
-            expect(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE, message);
+            Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE, message);
         }
     }
 
@@ -39,21 +35,21 @@ public class ExpectInteger_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE);
+        Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE);
     }
 
     @isTest
     static void ExpectNegatedLastsForOneTest() {
-        expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE)
+        Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE)
             .shouldEqual(INTEGER_LOWEST);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST);
+            Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST);
         }
         protected override void testCase(string message) {
-            expect(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST, message);
+            Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST, message);
         }
     }
 

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -7,17 +7,21 @@ public class ExpectInteger_Tests {
     private static final String INTEGER_MIDDLE_S = String.valueOf(INTEGER_MIDDLE);
     private static final String INTEGER_HIGHEST_S = String.valueOf(INTEGER_HIGHEST);
 
+    private static ExpectInteger expect(Integer i) {
+        return Expect.that(i);
+    }
+
     @isTest
     static void ExpectShouldEqualMatchingValueDoesNotThrow() {
-        Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_LOWEST);
+        expect(INTEGER_LOWEST).toEqual(INTEGER_LOWEST);
     }
 
     private class ShouldEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE);
+            expect(INTEGER_LOWEST).toEqual(INTEGER_MIDDLE);
         }
         protected override void testCase(string message) {
-            Expect.that(INTEGER_LOWEST).shouldEqual(INTEGER_MIDDLE, message);
+            expect(INTEGER_LOWEST).toEqual(INTEGER_MIDDLE, message);
         }
     }
 
@@ -35,15 +39,21 @@ public class ExpectInteger_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that(INTEGER_LOWEST).shouldNotEqual(INTEGER_MIDDLE);
+        expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectNNotLastsForOneTest() {
+        expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_MIDDLE)
+            .toEqual(INTEGER_LOWEST);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(INTEGER_LOWEST).shouldNotEqual(INTEGER_LOWEST);
+            expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that(INTEGER_LOWEST).shouldNotEqual(INTEGER_LOWEST, message);
+            expect(INTEGER_LOWEST).nnot.toEqual(INTEGER_LOWEST, message);
         }
     }
 
@@ -62,6 +72,16 @@ public class ExpectInteger_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(INTEGER_LOWEST).shouldBeLessThan(INTEGER_MIDDLE);
+        Expect.that(INTEGER_LOWEST).shouldBe.lessThan(INTEGER_MIDDLE)
+            .andShouldBe.lessThan(INTEGER_HIGHEST);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST);
+
+        Expect.that(INTEGER_MIDDLE).shouldNotBe.lessThan(INTEGER_LOWEST)
+            .andShouldNotBe.lessThan(-INTEGER_MIDDLE);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -197,7 +217,7 @@ public class ExpectInteger_Tests {
     @isTest
     static void ExpectIntegerChains() {
         Expect.that(INTEGER_LOWEST).shouldBeLessThan(INTEGER_MIDDLE)
-            .andit.shouldEqual(INTEGER_LOWEST);
+            .andit.toEqual(INTEGER_LOWEST);
     }
 
 }

--- a/src/classes/ExpectInteger_Tests.cls
+++ b/src/classes/ExpectInteger_Tests.cls
@@ -38,12 +38,6 @@ public class ExpectInteger_Tests {
         Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE);
     }
 
-    @isTest
-    static void ExpectNegatedLastsForOneTest() {
-        Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_MIDDLE)
-            .shouldEqual(INTEGER_LOWEST);
-    }
-
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
             Expect.that(INTEGER_LOWEST).negated.shouldEqual(INTEGER_LOWEST);
@@ -73,8 +67,7 @@ public class ExpectInteger_Tests {
     @isTest
     static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
         Expect.that(INTEGER_MIDDLE).negated.shouldBeLessThan(INTEGER_LOWEST)
-            .andIt.shouldBeLessThan(INTEGER_HIGHEST)
-            .andIt.negated.shouldBeLessThan(-INTEGER_MIDDLE);
+            .andIt.shouldBeLessThan(INTEGER_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {

--- a/src/classes/ExpectObject.cls
+++ b/src/classes/ExpectObject.cls
@@ -6,13 +6,18 @@ public class ExpectObject extends Expect {
         this.expected = expected;
     }
 
+    private ExpectObject(ExpectObject existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
+    }
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
 
     private ExpectObject assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return this;
+        assertNegatable(test, message);
+        return (ExpectObject) parentInstance;
     }
 
     public ExpectObject shouldEqual(Object actual) {
@@ -23,14 +28,6 @@ public class ExpectObject extends Expect {
         return assertThis(expected === actual, message);
     }
 
-    public Expect shouldNotEqual(Object actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(actual));
-    }
-
-    public Expect shouldNotEqual(Object actual, String message) {
-        return assertThis(expected !== actual, message);
-    }
-
     public ExpectObject shouldBeEquivalentTo(Object actual) {
         return shouldBeEquivalentTo(actual, expectedShouldBeMessage(actual));
     }
@@ -39,13 +36,11 @@ public class ExpectObject extends Expect {
         return assertThis(expected == actual, message);
     }
 
-    public ExpectObject shouldNotBeEquivalentTo(Object actual) {
-        return shouldNotBeEquivalentTo(actual, expectedShouldNotBeMessage(actual));
-    }
+    public ExpectObject andIt { get { return (ExpectObject) parentInstance; } }
 
-    public ExpectObject shouldNotBeEquivalentTo(Object actual, string message) {
-        return assertThis(expected != actual, message);
+    public ExpectObject negated {
+        get {
+            return new ExpectObject(this);
+        }
     }
-
-    public ExpectObject andIt { get { return this; } }
 }

--- a/src/classes/ExpectObject.cls
+++ b/src/classes/ExpectObject.cls
@@ -21,7 +21,7 @@ public class ExpectObject extends Expect {
     }
 
     public ExpectObject shouldEqual(Object actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(actual));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, actual));
     }
 
     public ExpectObject shouldEqual(Object actual, String message) {
@@ -29,7 +29,7 @@ public class ExpectObject extends Expect {
     }
 
     public ExpectObject shouldBeEquivalentTo(Object actual) {
-        return shouldBeEquivalentTo(actual, expectedShouldBeMessage(actual));
+        return shouldBeEquivalentTo(actual, formatMessage(SHOULD_BE_MESSAGE, actual));
     }
 
     public ExpectObject shouldBeEquivalentTo(Object actual, String message) {

--- a/src/classes/ExpectObject_Tests.cls
+++ b/src/classes/ExpectObject_Tests.cls
@@ -61,21 +61,21 @@ public class ExpectObject_Tests {
 
     @isTest
     static void ExpectNotEqualObjectsShouldNotThrowForNotEquals() {
-        Expect.that(EqualsOneInstanceA).shouldNotEqual(EqualsOneInstanceB);
+        Expect.that(EqualsOneInstanceA).negated.shouldEqual(EqualsOneInstanceB);
     }
 
     @isTest
     static void ExpectSObjectsExposesAndIt() {
-        Expect.that(EqualsOneInstanceA).shouldEqual(EqualsOneInstanceA).andIt.shouldNotEqual(EqualsOneInstanceB);
+        Expect.that(EqualsOneInstanceA).shouldEqual(EqualsOneInstanceA).andIt.negated.shouldEqual(EqualsOneInstanceB);
     }
 
     private class NotEqualObject extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(EqualsOneInstanceA).shouldNotEqual(EqualsOneInstanceA);
+            Expect.that(EqualsOneInstanceA).negated.shouldEqual(EqualsOneInstanceA);
         }
 
         protected override void testCase(String message) {
-            Expect.that(EqualsOneInstanceA).shouldNotEqual(EqualsOneInstanceA, message);
+            Expect.that(EqualsOneInstanceA).negated.shouldEqual(EqualsOneInstanceA, message);
         }
     }
 
@@ -87,16 +87,16 @@ public class ExpectObject_Tests {
 
     @isTest
     static void ExpectShouldNotBeEquivalentDoesNotThrow() {
-        Expect.that(EqualsOneInstanceA).shouldNotBeEquivalentTo(EqualsTwo);
-        Expect.that(EqualsOneInstanceA).shouldNotBeEquivalentTo(EqualsTwo, 'NotEquivalent');
+        Expect.that(EqualsOneInstanceA).negated.shouldBeEquivalentTo(EqualsTwo);
+        Expect.that(EqualsOneInstanceA).negated.shouldBeEquivalentTo(EqualsTwo, 'NotEquivalent');
     }
 
     private class ShouldNotBeEquivalentThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(EqualsOneInstanceA).shouldNotBeEquivalentTo(EqualsOneInstanceB);
+            Expect.that(EqualsOneInstanceA).negated.shouldBeEquivalentTo(EqualsOneInstanceB);
         }
         protected override void testCase(String message) {
-            Expect.that(EqualsOneInstanceA).shouldNotBeEquivalentTo(EqualsOneInstanceB, message);
+            Expect.that(EqualsOneInstanceA).negated.shouldBeEquivalentTo(EqualsOneInstanceB, message);
         }
     }
 

--- a/src/classes/ExpectSObject.cls
+++ b/src/classes/ExpectSObject.cls
@@ -45,12 +45,12 @@ public class ExpectSObject extends Expect {
     }
 
     private ExpectSObject assertSObject(Boolean test, String message) {
-        assert(test, message);
+        assertNegatable(test, message);
         return this;
     }
 
     private ExpectError failDmlExpectation(string dmlOperationName) {
-        assert(false, 'Expected ' + String.valueOf(expected) + ' should error on ' + dmlOperationName);
+        assertNegatable(false, 'Expected ' + String.valueOf(expected) + ' should error on ' + dmlOperationName);
         return null;
     }
 

--- a/src/classes/ExpectSObject.cls
+++ b/src/classes/ExpectSObject.cls
@@ -3,29 +3,32 @@ public class ExpectSObject extends Expect {
 
     public ExpectSObject(SObject expected) {
         this.expected = expected;
+
+    }
+    private ExpectSObject(ExpectSObject existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
 
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
 
-    public ExpectSObject andIt { get { return this; } }
+    public ExpectSObject andIt { get { return (ExpectSObject) parentInstance; } }
+
+    public ExpectSObject negated {
+        get {
+            return new ExpectSObject(this);
+        }
+    }
 
     public ExpectSObject shouldEqual(SObject actual) {
-        shouldEqual(actual, expectedShouldBeMessage(actual));
+        shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, actual));
         return this;
     }
 
     public ExpectSObject shouldEqual(SObject actual, String message) {
         return assertSObject(expected === actual, message);
-    }
-
-    public ExpectSObject shouldNotEqual(SObject actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(actual));
-    }
-
-    public ExpectSObject shouldNotEqual(SObject actual, String message) {
-        return assertSObject(expected !== actual, message);
     }
 
     public ExpectSObject sObjectTypeEquals(SObject actual) {
@@ -37,7 +40,7 @@ public class ExpectSObject extends Expect {
     }
 
     public ExpectSObject sObjectTypeEquals(SObjectType objType) {
-        return sObjectTypeEquals(objType, expectedShouldBeMessage(objType));
+        return sObjectTypeEquals(objType, formatMessage(SHOULD_BE_MESSAGE, objType));
     }
 
     public ExpectSObject sObjectTypeEquals(SObjectType objType, String message) {

--- a/src/classes/ExpectSObjectType.cls
+++ b/src/classes/ExpectSObjectType.cls
@@ -4,6 +4,10 @@ public class ExpectSObjectType extends Expect {
     public ExpectSObjectType(SObjectType expected) {
         this.expected = expected;
     }
+    private ExpectSObjectType(ExpectSObjectType existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
+    }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
@@ -11,21 +15,14 @@ public class ExpectSObjectType extends Expect {
         SObject[] records = Database.query('select Id from ' + expected.getDescribe().getName() + ' LIMIT 1');
         return records.size() > 0;
     }
-    public ExpectSObjectType shouldNotHaveRecords() {
-        shouldNotHaveRecords(expectedFormatNotMessage(SHOULD_HAVE_RECORDS, null));
-        return this;
-    }
-    public ExpectSObjectType shouldNotHaveRecords(String message) {
-        assert(isRecord() == false, message);
-        return this;
-    }
     public ExpectSObjectType shouldHaveRecords() {
-        shouldHaveRecords(expectedFormatMessage(SHOULD_HAVE_RECORDS, null));
-        return this;
+        shouldHaveRecords(formatMessage(SHOULD_HAVE_RECORDS, null));
+        return (ExpectSObjectType) parentInstance;
     }
     public ExpectSObjectType shouldHaveRecords(String message) {
-        assert(isRecord(), message);
-        return this;
+        assertNegatable(isRecord(), message);
+        return (ExpectSObjectType) parentInstance;
     }
-    public ExpectSObjectType andIt { get { return this; } }
+    public ExpectSObjectType andIt { get { return (ExpectSObjectType) parentInstance; } }
+    public ExpectSObjectType negated { get { return new ExpectSObjectType(this); }}
 }

--- a/src/classes/ExpectSObjectType_Tests.cls
+++ b/src/classes/ExpectSObjectType_Tests.cls
@@ -4,7 +4,7 @@ public class ExpectSObjectType_Tests {
 
     @isTest
     static void ExpectShouldNotHaveRecordsDoesNotThrow() {
-        sObjectTypeExpectation.shouldNotHaveRecords();
+        sObjectTypeExpectation.negated.shouldHaveRecords();
     }
 
     private class ShouldNotHaveRecordsThrows extends ThrowCheck {
@@ -12,11 +12,11 @@ public class ExpectSObjectType_Tests {
             insert new Account(Name='NewAccount');
         }
         protected override void testCase() {
-            sObjectTypeExpectation.shouldNotHaveRecords();
+            sObjectTypeExpectation.negated.shouldHaveRecords();
         }
 
         protected override void testCase(String message) {
-            sObjectTypeExpectation.shouldNotHaveRecords(message);
+            sObjectTypeExpectation.negated.shouldHaveRecords(message);
         }
     }
 
@@ -28,7 +28,7 @@ public class ExpectSObjectType_Tests {
 
     @isTest
     static void ExpectShouldHaveRecordsDoesNotThrow() {
-        new ExpectSObjectType(Schema.Account.SObjectType).shouldNotHaveRecords();
+        new ExpectSObjectType(Schema.Account.SObjectType).negated.shouldHaveRecords();
     }
 
     private class ShouldHaveRecordsThrows extends ThrowCheck {

--- a/src/classes/ExpectSObject_Tests.cls
+++ b/src/classes/ExpectSObject_Tests.cls
@@ -36,20 +36,20 @@ public class ExpectSObject_Tests {
         Account one = getAccount();
         Account two = getAccount();
 
-        Expect.that(one).shouldNotEqual(two);
+        Expect.that(one).negated.shouldEqual(two);
     }
 
     private class EqualObjectShouldThrowForNotEqual extends ThrowCheck {
         protected override void testCase() {
             Account one = getAccount();
             Account two = one;
-            Expect.that(one).shouldNotEqual(two);
+            Expect.that(one).negated.shouldEqual(two);
         }
 
         protected override void testCase(String message) {
             Account one = getAccount();
             Account two = one;
-            Expect.that(one).shouldNotEqual(two, message);
+            Expect.that(one).negated.shouldEqual(two, message);
         }
     }
 
@@ -88,7 +88,7 @@ public class ExpectSObject_Tests {
 
         sObjectInstance = new Account();
 
-        Expect.that(sObjectInstance).shouldNotEqual(null);
+        Expect.that(sObjectInstance).negated.shouldEqual(null);
     }
 
     @isTest
@@ -96,7 +96,7 @@ public class ExpectSObject_Tests {
         Account oneAccount = getAccount();
         Account twoAccount = getAccount();
 
-        Expect.that(oneAccount).shouldNotEqual(twoAccount);
+        Expect.that(oneAccount).negated.shouldEqual(twoAccount);
     }
 
     @isTest

--- a/src/classes/ExpectString.cls
+++ b/src/classes/ExpectString.cls
@@ -7,7 +7,7 @@ public class ExpectString extends ExpectStringBase {
     }
 
     public ExpectString shouldEqualIgnoreOrdinalCase(String actual) {
-        return shouldEqualIgnoreOrdinalCase(actual, expectedShouldBeMessage(actual));
+        return shouldEqualIgnoreOrdinalCase(actual, formatMessage(SHOULD_BE_MESSAGE, actual));
     }
 
     public ExpectString shouldEqualIgnoreOrdinalCase(String actual, String message) {
@@ -15,7 +15,7 @@ public class ExpectString extends ExpectStringBase {
     }
 
     public ExpectString shouldContain(String actual) {
-        return shouldContain(actual, expectedFormatMessage(SHOULD_CONTAIN_MESSAGE, actual));
+        return shouldContain(actual, formatMessage(SHOULD_CONTAIN_MESSAGE, actual));
     }
 
     public ExpectString shouldContain(String actual, String message) {

--- a/src/classes/ExpectString.cls
+++ b/src/classes/ExpectString.cls
@@ -2,6 +2,9 @@ public class ExpectString extends ExpectStringBase {
     public ExpectString(string s) {
         super(s);
     }
+    public ExpectString(String expected, Boolean negate, ExpectString parent) {
+        super(expected, negate, parent);
+    }
 
     public ExpectString shouldEqualIgnoreOrdinalCase(String actual) {
         return shouldEqualIgnoreOrdinalCase(actual, expectedShouldBeMessage(actual));

--- a/src/classes/ExpectString.cls
+++ b/src/classes/ExpectString.cls
@@ -2,8 +2,8 @@ public class ExpectString extends ExpectStringBase {
     public ExpectString(string s) {
         super(s);
     }
-    public ExpectString(String expected, Boolean negate, ExpectString parent) {
-        super(expected, negate, parent);
+    public ExpectString(ExpectString parent) {
+        super(parent);
     }
 
     public ExpectString shouldEqualIgnoreOrdinalCase(String actual) {
@@ -20,13 +20,5 @@ public class ExpectString extends ExpectStringBase {
 
     public ExpectString shouldContain(String actual, String message) {
         return assertThis(expected.contains(actual), message);
-    }
-
-    public ExpectString shouldNotContain(String actual) {
-        return shouldNotContain(actual, expectedFormatNotMessage(SHOULD_CONTAIN_MESSAGE, actual));
-    }
-
-    public ExpectString shouldNotContain(String actual, String message) {
-        return assertThis(expected.containsNone(actual), message);
     }
 }

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -28,25 +28,25 @@ public abstract class ExpectStringBase extends Expect {
         return assertThis(expected < actual, message);
     }
     public ExpectString shouldBeLessThan(String actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public ExpectString shouldBeLessThanOrEqualTo(String actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public ExpectString shouldBeLessThanOrEqualTo(String actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectString shouldBeGreaterThan(String actual, string message) {
         return assertThis(expected > actual, message);
     }
     public ExpectString shouldBeGreaterThan(String actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public ExpectString shouldBeGreaterThanOrEqualTo(String actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public ExpectString shouldBeGreaterThanOrEqualTo(String actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public ExpectString shouldBeBetween(String rangeStart, String rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -3,8 +3,8 @@ public virtual class ExpectStringBase extends Expect {
     protected final ExpectString parent;
 
     protected ExpectStringBase(String expected) {
-        this.expected = expected;
         this.parent = (ExpectString) this;
+        this.expected = expected;
     }
     protected ExpectStringBase(String expected, Boolean negate, ExpectString parent) {
         super(negate);

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -8,11 +8,9 @@ public abstract class ExpectStringBase extends Expect {
         super(NegatedAssert, existingInstance);
         this.expected = existingInstance.expected;
     }
-    public ExpectString negated {
-        get {
-            return new ExpectString((ExpectString) this);
-        }
-    }
+
+    public ExpectString negated { get { return new ExpectString((ExpectString) this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -1,4 +1,4 @@
-public virtual class ExpectStringBase extends Expect {
+public abstract class ExpectStringBase extends Expect {
     protected final String expected;
     protected final ExpectString parent;
 

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -1,19 +1,16 @@
 public abstract class ExpectStringBase extends Expect {
     protected final String expected;
-    protected final ExpectString parent;
 
     protected ExpectStringBase(String expected) {
-        this.parent = (ExpectString) this;
         this.expected = expected;
     }
-    protected ExpectStringBase(String expected, Boolean negate, ExpectString parent) {
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+    protected ExpectStringBase(ExpectString existingInstance) {
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
     public ExpectString negated {
         get {
-            return negate ? (ExpectString) this : new ExpectString(this.expected, true, (ExpectString) this);
+            return new ExpectString((ExpectString) this);
         }
     }
     protected override String getExpectedAsString() {
@@ -21,7 +18,7 @@ public abstract class ExpectStringBase extends Expect {
     }
     protected ExpectString assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return (ExpectString) this.parent;
+        return (ExpectString) parentInstance;
     }
     public ExpectString shouldEqual(String actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -63,5 +60,5 @@ public abstract class ExpectStringBase extends Expect {
 
         return assertThis(testedBetween, message);
     }
-    public ExpectString andIt { get { return (ExpectString) this; } }
+    public ExpectString andIt { get { return (ExpectString) parentInstance; } }
 }

--- a/src/classes/ExpectStringBase.cls
+++ b/src/classes/ExpectStringBase.cls
@@ -1,27 +1,33 @@
 public virtual class ExpectStringBase extends Expect {
     protected final String expected;
+    protected final ExpectString parent;
 
     protected ExpectStringBase(String expected) {
         this.expected = expected;
+        this.parent = (ExpectString) this;
+    }
+    protected ExpectStringBase(String expected, Boolean negate, ExpectString parent) {
+        super(negate);
+        this.expected = expected;
+        this.parent = parent;
+    }
+    public ExpectString negated {
+        get {
+            return negate ? (ExpectString) this : new ExpectString(this.expected, true, (ExpectString) this);
+        }
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     protected ExpectString assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return (ExpectString) this;
+        assertNegatable(test, message);
+        return (ExpectString) this.parent;
     }
     public ExpectString shouldEqual(String actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public ExpectString shouldEqual(String actual, String message) {
         return assertThis(expected.equals(actual), message);
-    }
-    public ExpectString shouldNotEqual(String actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public ExpectString shouldNotEqual(String actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public ExpectString shouldBeLessThan(String actual, string message) {
         return assertThis(expected < actual, message);

--- a/src/classes/ExpectStringBase_Tests.cls
+++ b/src/classes/ExpectStringBase_Tests.cls
@@ -35,15 +35,15 @@ public class ExpectStringBase_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that(STRING_LOWEST).shouldNotEqual(STRING_MIDDLE);
+        Expect.that(STRING_LOWEST).negated.shouldEqual(STRING_MIDDLE);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that(STRING_LOWEST).shouldNotEqual(STRING_LOWEST);
+            Expect.that(STRING_LOWEST).negated.shouldEqual(STRING_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that(STRING_LOWEST).shouldNotEqual(STRING_LOWEST, message);
+            Expect.that(STRING_LOWEST).negated.shouldEqual(STRING_LOWEST, message);
         }
     }
 
@@ -62,6 +62,12 @@ public class ExpectStringBase_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that(STRING_LOWEST).shouldBeLessThan(STRING_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that(STRING_MIDDLE).negated.shouldBeLessThan(STRING_LOWEST)
+            .andIt.shouldBeLessThan(STRING_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -191,6 +197,27 @@ public class ExpectStringBase_Tests {
     @isTest
     static void ExpectShouldBeBetweenThrowsSpecificMessage() {
         new ShouldBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that(STRING_MIDDLE).negated.shouldBeBetween(STRING_LOWEST, STRING_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that(STRING_MIDDLE).negated.shouldBeBetween(STRING_LOWEST, STRING_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + STRING_MIDDLE_S + ' should not be between ' + STRING_LOWEST_S + ' and ' + STRING_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
             .verifyCustomMessage('outside allowed range');
     }
 

--- a/src/classes/ExpectString_Tests.cls
+++ b/src/classes/ExpectString_Tests.cls
@@ -45,16 +45,16 @@ public class ExpectString_Tests {
 
     @isTest
     static void ExpectStringShouldNotContainDoesNotThrowWhenStringDoesNotContain() {
-        Expect.that('a').shouldNotContain('A');
+        Expect.that('a').negated.shouldContain('A');
     }
 
     private class ShouldNotContainThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that('ab').shouldNotContain('ab');
+            Expect.that('ab').negated.shouldContain('ab');
         }
 
         protected override void testCase(String message) {
-            Expect.that('ab').shouldNotContain('ab', message);
+            Expect.that('ab').negated.shouldContain('ab', message);
         }
     }
 

--- a/template/my-template-test.hbs
+++ b/template/my-template-test.hbs
@@ -35,15 +35,15 @@ public class Expect{{datatype}}{{#if subclass}}Base{{/if}}_Tests {
 
     @isTest
     static void ExpectShouldNotEqualDoesNotThrow() {
-        Expect.that({{upper datatype}}_LOWEST).shouldNotEqual({{upper datatype}}_MIDDLE);
+        Expect.that({{upper datatype}}_LOWEST).negated.shouldEqual({{upper datatype}}_MIDDLE);
     }
 
     private class ShouldNotEqualThrows extends ThrowCheck {
         protected override void testCase() {
-            Expect.that({{upper datatype}}_LOWEST).shouldNotEqual({{upper datatype}}_LOWEST);
+            Expect.that({{upper datatype}}_LOWEST).negated.shouldEqual({{upper datatype}}_LOWEST);
         }
         protected override void testCase(string message) {
-            Expect.that({{upper datatype}}_LOWEST).shouldNotEqual({{upper datatype}}_LOWEST, message);
+            Expect.that({{upper datatype}}_LOWEST).negated.shouldEqual({{upper datatype}}_LOWEST, message);
         }
     }
 
@@ -62,6 +62,12 @@ public class Expect{{datatype}}{{#if subclass}}Base{{/if}}_Tests {
     @isTest
     static void ExpectShouldBeLessThanDoesNotThrow() {
         Expect.that({{upper datatype}}_LOWEST).shouldBeLessThan({{upper datatype}}_MIDDLE);
+    }
+
+    @isTest
+    static void ExpectShouldBeLessThanNegatedDoesNotThrow() {
+        Expect.that({{upper datatype}}_MIDDLE).negated.shouldBeLessThan({{upper datatype}}_LOWEST)
+            .andIt.shouldBeLessThan({{upper datatype}}_HIGHEST);
     }
 
     private class ShouldBeLessThanThrows extends ThrowCheck {
@@ -191,6 +197,27 @@ public class Expect{{datatype}}{{#if subclass}}Base{{/if}}_Tests {
     @isTest
     static void ExpectShouldBeBetweenThrowsSpecificMessage() {
         new ShouldBeBetweenThrows()
+            .verifyCustomMessage('outside allowed range');
+    }
+
+    private class ShouldNotBeBetweenThrows extends ThrowCheck {
+        protected override void testCase() {
+            Expect.that({{upper datatype}}_MIDDLE).negated.shouldBeBetween({{upper datatype}}_LOWEST, {{upper datatype}}_HIGHEST);
+        }
+        protected override void testCase(String message) {
+            Expect.that({{upper datatype}}_MIDDLE).negated.shouldBeBetween({{upper datatype}}_LOWEST, {{upper datatype}}_HIGHEST, message);
+        }
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsThrowsDefaultMessage() {
+        new ShouldNotBeBetweenThrows()
+            .verifyMessage('Expected ' + {{upper datatype}}_MIDDLE_S + ' should not be between ' + {{upper datatype}}_LOWEST_S + ' and ' + {{upper datatype}}_HIGHEST_S);
+    }
+
+    @isTest
+    static void ExpectShouldNotBeBetweenThrowsSpecificMessage() {
+        new ShouldNotBeBetweenThrows()
             .verifyCustomMessage('outside allowed range');
     }
 

--- a/template/my-template.hbs
+++ b/template/my-template.hbs
@@ -4,14 +4,15 @@ public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Ba
 
 {{#if subclass}}
     protected Expect{{datatype}}Base({{datatype}} expected) {
+        this.parent = (Expect{{datatype}}) this;
 {{else}}
     public Expect{{datatype}}({{datatype}} expected) {
+        this.parent = this;
 {{/if}}
         this.expected = expected;
-        this.parent = this;
     }
 {{#if subclass}}
-    protected Expect{{datatype}}Base({{datatype}} expected, Boolean negate, Expect{{datatype}}Base parent) {
+    protected Expect{{datatype}}Base({{datatype}} expected, Boolean negate, Expect{{datatype}} parent) {
 {{else}}
     private Expect{{datatype}}({{datatype}} expected, Boolean negate, Expect{{datatype}} parent) {
 {{/if}}
@@ -21,7 +22,7 @@ public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Ba
     }
     public Expect{{datatype}} negated {
         get {
-            return negate ? {{#if subclass}}(Expect{{datatype}}) {{/if}}this : new Expect{{datatype}}(this.expected, true, this);
+            return negate ? {{#if subclass}}(Expect{{datatype}}) {{/if}}this : new Expect{{datatype}}(this.expected, true, {{#if subclass}}(Expect{{datatype}}) {{/if}}this);
         }
     }
     protected override String getExpectedAsString() {

--- a/template/my-template.hbs
+++ b/template/my-template.hbs
@@ -40,25 +40,25 @@ public {{#if subclass}}abstract {{/if}}class Expect{{datatype}}{{#if subclass}}B
         return assertThis(expected < actual, message);
     }
     public Expect{{datatype}} shouldBeLessThan({{datatype}} actual) {
-        return shouldBeLessThan(actual, expectedFormatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThan(actual, formatMessage(SHOULD_BE_LESS_MESSAGE, String.valueOf(actual)));
     }
     public Expect{{datatype}} shouldBeLessThanOrEqualTo({{datatype}} actual, string message) {
         return assertThis(expected <= actual, message);
     }
     public Expect{{datatype}} shouldBeLessThanOrEqualTo({{datatype}} actual) {
-        return shouldBeLessThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeLessThanOrEqualTo(actual, formatMessage(SHOULD_BE_LESS_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public Expect{{datatype}} shouldBeGreaterThan({{datatype}} actual, string message) {
         return assertThis(expected > actual, message);
     }
     public Expect{{datatype}} shouldBeGreaterThan({{datatype}} actual) {
-        return shouldBeGreaterThan(actual, expectedFormatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThan(actual, formatMessage(SHOULD_BE_GREATER_MESSAGE, String.valueOf(actual)));
     }
     public Expect{{datatype}} shouldBeGreaterThanOrEqualTo({{datatype}} actual, string message) {
         return assertThis(expected >= actual, message);
     }
     public Expect{{datatype}} shouldBeGreaterThanOrEqualTo({{datatype}} actual) {
-        return shouldBeGreaterThanOrEqualTo(actual, expectedFormatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
+        return shouldBeGreaterThanOrEqualTo(actual, formatMessage(SHOULD_BE_GREATER_OR_EQUAL_MESSAGE, String.valueOf(actual)));
     }
     public Expect{{datatype}} shouldBeBetween({{datatype}} rangeStart, {{datatype}} rangeEnd) {
         return shouldBeBetween(rangeStart, rangeEnd, expectedShouldBeBetweenMessage(String.valueOf(rangeStart), String.valueOf(rangeEnd)));

--- a/template/my-template.hbs
+++ b/template/my-template.hbs
@@ -1,5 +1,6 @@
 public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Base{{/if}} extends Expect {
     protected final {{datatype}} expected;
+    protected final Expect{{datatype}} parent;
 
 {{#if subclass}}
     protected Expect{{datatype}}Base({{datatype}} expected) {
@@ -7,16 +8,31 @@ public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Ba
     public Expect{{datatype}}({{datatype}} expected) {
 {{/if}}
         this.expected = expected;
+        this.parent = this;
+    }
+{{#if subclass}}
+    protected Expect{{datatype}}Base({{datatype}} expected, Boolean negate, Expect{{datatype}}Base parent) {
+{{else}}
+    private Expect{{datatype}}({{datatype}} expected, Boolean negate, Expect{{datatype}} parent) {
+{{/if}}
+        super(negate);
+        this.expected = expected;
+        this.parent = parent;
+    }
+    public Expect{{datatype}} negated {
+        get {
+            return negate ? {{#if subclass}}(Expect{{datatype}}) {{/if}}this : new Expect{{datatype}}(this.expected, true, this);
+        }
     }
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     {{#if subclass}}protected{{else}}private{{/if}} Expect{{datatype}} assertThis(Boolean test, String message) {
-        Expect.assert(test, message);
-        return {{#if subclass}}(Expect{{datatype}}) {{/if}}this;
+        assertNegatable(test, message);
+        return {{#if subclass}}(Expect{{datatype}}) {{/if}}this.parent;
     }
     public Expect{{datatype}} shouldEqual({{datatype}} actual) {
-        return shouldEqual(actual, expectedShouldBeMessage(String.valueOf(actual)));
+        return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
     }
     public Expect{{datatype}} shouldEqual({{datatype}} actual, String message) {
 {{#if equalityExpression}}
@@ -24,12 +40,6 @@ public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Ba
 {{else}}
         return assertThis(expected == actual, message);
 {{/if}}
-    }
-    public Expect{{datatype}} shouldNotEqual({{datatype}} actual) {
-        return shouldNotEqual(actual, expectedShouldNotBeMessage(String.valueOf(actual)));
-    }
-    public Expect{{datatype}} shouldNotEqual({{datatype}} actual, String message) {
-        return assertThis(expected != actual, message);
     }
     public Expect{{datatype}} shouldBeLessThan({{datatype}} actual, string message) {
         return assertThis(expected < actual, message);

--- a/template/my-template.hbs
+++ b/template/my-template.hbs
@@ -1,36 +1,30 @@
 public {{#if subclass}}abstract {{/if}}class Expect{{datatype}}{{#if subclass}}Base{{/if}} extends Expect {
     protected final {{datatype}} expected;
-    protected final Expect{{datatype}} parent;
 
 {{#if subclass}}
     protected Expect{{datatype}}Base({{datatype}} expected) {
-        this.parent = (Expect{{datatype}}) this;
 {{else}}
     public Expect{{datatype}}({{datatype}} expected) {
-        this.parent = this;
 {{/if}}
         this.expected = expected;
     }
 {{#if subclass}}
-    protected Expect{{datatype}}Base({{datatype}} expected, Boolean negate, Expect{{datatype}} parent) {
+    protected Expect{{datatype}}Base(Expect{{datatype}} existingInstance) {
 {{else}}
-    private Expect{{datatype}}({{datatype}} expected, Boolean negate, Expect{{datatype}} parent) {
+    private Expect{{datatype}}(Expect{{datatype}} existingInstance) {
 {{/if}}
-        super(negate);
-        this.expected = expected;
-        this.parent = parent;
+        super(NegatedAssert, existingInstance);
+        this.expected = existingInstance.expected;
     }
-    public Expect{{datatype}} negated {
-        get {
-            return negate ? {{#if subclass}}(Expect{{datatype}}) {{/if}}this : new Expect{{datatype}}(this.expected, true, {{#if subclass}}(Expect{{datatype}}) {{/if}}this);
-        }
-    }
+
+    public Expect{{datatype}} negated { get { return new Expect{{datatype}}({{#if subclass}}(Expect{{datatype}}) {{/if}}this); }}
+
     protected override String getExpectedAsString() {
         return String.valueOf(expected);
     }
     {{#if subclass}}protected{{else}}private{{/if}} Expect{{datatype}} assertThis(Boolean test, String message) {
         assertNegatable(test, message);
-        return {{#if subclass}}(Expect{{datatype}}) {{/if}}this.parent;
+        return (Expect{{datatype}}) parentInstance;
     }
     public Expect{{datatype}} shouldEqual({{datatype}} actual) {
         return shouldEqual(actual, formatMessage(SHOULD_BE_MESSAGE, String.valueOf(actual)));
@@ -76,5 +70,5 @@ public {{#if subclass}}abstract {{/if}}class Expect{{datatype}}{{#if subclass}}B
 
         return assertThis(testedBetween, message);
     }
-    public Expect{{datatype}} andIt { get { return{{#if subclass}} (Expect{{datatype}}){{/if}} this; } }
+    public Expect{{datatype}} andIt { get { return (Expect{{datatype}}) parentInstance; } }
 }

--- a/template/my-template.hbs
+++ b/template/my-template.hbs
@@ -1,4 +1,4 @@
-public {{#if subclass}}virtual {{/if}}class Expect{{datatype}}{{#if subclass}}Base{{/if}} extends Expect {
+public {{#if subclass}}abstract {{/if}}class Expect{{datatype}}{{#if subclass}}Base{{/if}} extends Expect {
     protected final {{datatype}} expected;
     protected final Expect{{datatype}} parent;
 


### PR DESCRIPTION
relates to issue #19 

Found i could not use a base class in a test to make a method available

```apex
public class TestHelper {
static ExpectInteger help(integer i) { /* stuff */ }
}
public class Helped extends TestHelper {
@isTest
static void helpit() {
help(5); // <- method not found. 
}
```

This PR demos a few different options

-   more closely align to https://github.com/mjackson/expect
```apex
Expect.expect(5).nnot.toEqual(6); // can't name any property not!
Expect.expect(5).toEqual(5);
```

-  more closely align to https://github.com/shouldjs/should.js
```apex
Expect.that(5).shouldBe.lessThan(7);
Expect.that(5).shouldNotBe.lessThan(4);
```

-  allow chaining with shouldBe and shouldNotBe
```apex
Expect.that(5).lessThan(9).andShouldNotBe.lessThan(4);
```

- use negated and don't neccesarily introduce anything else
```apex
Expect.that(5).negated.shouldBeGreaterThan(6)
  .andIt.negated.shouldBeGreaterThan(7);
```